### PR TITLE
Always return something from `getStyle()` to avoid errors

### DIFF
--- a/get-size.js
+++ b/get-size.js
@@ -100,7 +100,7 @@ function setup() {
             '. Are you running this code in a hidden iframe on Firefox? ' +
             'See http://bit.ly/getsizebug1' );
         }
-        return style;
+        return style || {};
       };
   })();
 


### PR DESCRIPTION
cf https://bugzilla.mozilla.org/show_bug.cgi?id=548397
